### PR TITLE
Add initial Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+user_guide
+doc
+pkgdown

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,10 @@ RUN apt-get update \
 	liblzma-dev \
 	libbz2-dev \
 	libgit2-dev \
-	&& rm -rf /var/lib/apt/lists/*
-#	&& echo "options(repos = c(CRAN = '${CRAN_URL}', BIOC = '${BIOC_URL}'), " \
-#	    "download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site \
-RUN install2.r -s -e -n ${N_CPU_BUILD} BiocManager remotes mockr
-
-RUN echo "options(timeout = 300)" >> /usr/local/lib/R/etc/Rprofile.site
-
-RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r BSgenome.Hsapiens.UCSC.hg19
-
-RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r deconstructSigs \
+	&& rm -rf /var/lib/apt/lists/* \
+    && install2.r -s -e -n ${N_CPU_BUILD} BiocManager remotes mockr \
+    && echo "options(timeout = 300)" >> /usr/local/lib/R/etc/Rprofile.site \
+    && /usr/local/lib/R/site-library/littler/examples/installBioc.r BSgenome.Hsapiens.UCSC.hg19 \
+    && /usr/local/lib/R/site-library/littler/examples/installBioc.r deconstructSigs \
     && installGithub.r -u FALSE im3sanger/dndscv "Townsend-Lab-Yale/cancereffectsizeR@*release" \
-	&& installGithub.r -u FALSE "Townsend-Lab-Yale/ces.refset.hg19@*release"
+    && installGithub.r -u FALSE "Townsend-Lab-Yale/ces.refset.hg19@*release"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,14 @@ RUN apt-get update \
 	libbz2-dev \
 	libgit2-dev \
 	&& rm -rf /var/lib/apt/lists/* \
-    && install2.r -s -e -n ${N_CPU_BUILD} BiocManager remotes mockr \
-    && echo "options(timeout = 300)" >> /usr/local/lib/R/etc/Rprofile.site \
-    && /usr/local/lib/R/site-library/littler/examples/installBioc.r BSgenome.Hsapiens.UCSC.hg19 \
-    && /usr/local/lib/R/site-library/littler/examples/installBioc.r deconstructSigs \
-    && installGithub.r -u FALSE im3sanger/dndscv "Townsend-Lab-Yale/cancereffectsizeR@*release" \
-    && installGithub.r -u FALSE "Townsend-Lab-Yale/ces.refset.hg19@*release"
+	&& install2.r -s -e -n ${N_CPU_BUILD} BiocManager remotes mockr devtools \
+	&& echo "options(timeout = 300)" >> /usr/local/lib/R/etc/Rprofile.site \
+	&& /usr/local/lib/R/site-library/littler/examples/installBioc.r \
+		BSgenome.Hsapiens.UCSC.hg19 deconstructSigs \
+	&& installGithub.r -u FALSE "im3sanger/dndscv"
+
+COPY . /cancereffectsizeR
+
+RUN R -e 'remotes::install_local("/cancereffectsizeR", upgrade = FALSE, dependencies = TRUE)'
+
+RUN installGithub.r -u FALSE -d FALSE "Townsend-Lab-Yale/ces.refset.hg19@*release"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Partly based on https://github.com/Bioconductor/bioconductor_docker/blob/master/Dockerfile
-FROM rocker/rstudio:4.0.5
+# Bioconductor 3.12 built for R 4.0.3
+FROM rocker/rstudio:4.0.3
 
 # nuke cache dirs before installing pkgs; tip from Dirk E fixes broken img
 RUN rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
@@ -11,38 +12,25 @@ RUN dpkg --clear-avail
 # This is to avoid the error 'debconf: unable to initialize frontend: Dialog'
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG CRAN_URL="https://mran.microsoft.com/snapshot/2021-04-07"
-ARG BIOC_URL="http://bioconductor.org/packages/3.12/bioc"
 ARG N_CPU_BUILD=1
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends apt-utils \
 	&& apt-get install -y --no-install-recommends \
-	## Basic deps
-	gdb \
 	libxml2-dev \
-	python3-pip \
 	libz-dev \
 	liblzma-dev \
 	libbz2-dev \
-	libpng-dev \
 	libgit2-dev \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& echo "options(repos = c(CRAN = '${CRAN_URL}', BIOC = '${BIOC_URL}'), download.file.method = 'libcurl')" \
-		>> /usr/local/lib/R/etc/Rprofile.site \
-	# cran, excl deconstructSigs
-	&& install2.r -s -e -n ${N_CPU_BUILD} BH BiocManager MASS Matrix R6 RColorBrewer RCurl Rcpp XML ade4 askpass base64enc \
-		bbmle bdsmatrix bitops brio cachem callr cli clipr colorspace cpp11 crayon credentials curl data.table \
-		desc digest downlit ellipsis evaluate fansi farver fastmap formatR fs futile.logger futile.options gert \
-		ggplot2 ggrepel gh gitcreds glue gtable highr hms htmltools httr ini isoband jsonlite knitr labeling \
-		lambda.r lattice lazyeval lifecycle magrittr markdown matrixStats memoise mgcv mime mockr munsell \
-		mvtnorm nlme numDeriv openssl pbapply pillar pixmap pkgconfig pkgdown plyr poilog prettyunits processx \
-		progress ps purrr ragg rappdirs rematch2 renv reshape2 rlang rmarkdown rprojroot rstudioapi scales \
-		segmented seqinr snow sp stringi stringr sys systemfonts textshaping tibble tinytex usethis utf8 vctrs \
-		viridisLite whisker withr xfun xml2 yaml zip remotes \
-	&& /usr/local/lib/R/site-library/littler/examples/installBioc.r BSgenome BSgenome.Hsapiens.UCSC.hg19 Biobase \
-		BiocGenerics BiocParallel BiocVersion Biostrings DelayedArray GenomeInfoDb GenomeInfoDbData \
-		GenomicAlignments GenomicRanges IRanges MatrixGenerics Rhtslib Rsamtools S4Vectors SummarizedExperiment \
-		XVector rtracklayer zlibbioc deconstructSigs \
-	&& installGithub.r -u FALSE im3sanger/dndscv "Townsend-Lab-Yale/cancereffectsizeR@*release" \
+	&& rm -rf /var/lib/apt/lists/*
+#	&& echo "options(repos = c(CRAN = '${CRAN_URL}', BIOC = '${BIOC_URL}'), " \
+#	    "download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site \
+RUN install2.r -s -e -n ${N_CPU_BUILD} BiocManager remotes mockr
+
+RUN echo "options(timeout = 300)" >> /usr/local/lib/R/etc/Rprofile.site
+
+RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r BSgenome.Hsapiens.UCSC.hg19
+
+RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r deconstructSigs \
+    && installGithub.r -u FALSE im3sanger/dndscv "Townsend-Lab-Yale/cancereffectsizeR@*release" \
 	&& installGithub.r -u FALSE "Townsend-Lab-Yale/ces.refset.hg19@*release"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Partly based on https://github.com/Bioconductor/bioconductor_docker/blob/master/Dockerfile
+FROM rocker/rstudio:4.0.5
+
+# nuke cache dirs before installing pkgs; tip from Dirk E fixes broken img
+RUN rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
+
+# issues with '/var/lib/dpkg/available' not found
+# this will recreate
+RUN dpkg --clear-avail
+
+# This is to avoid the error 'debconf: unable to initialize frontend: Dialog'
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG CRAN_URL="https://mran.microsoft.com/snapshot/2021-04-07"
+ARG BIOC_URL="http://bioconductor.org/packages/3.12/bioc"
+ARG N_CPU_BUILD=1
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends apt-utils \
+	&& apt-get install -y --no-install-recommends \
+	## Basic deps
+	gdb \
+	libxml2-dev \
+	python3-pip \
+	libz-dev \
+	liblzma-dev \
+	libbz2-dev \
+	libpng-dev \
+	libgit2-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& echo "options(repos = c(CRAN = '${CRAN_URL}', BIOC = '${BIOC_URL}'), download.file.method = 'libcurl')" \
+		>> /usr/local/lib/R/etc/Rprofile.site \
+	# cran, excl deconstructSigs
+	&& install2.r -s -e -n ${N_CPU_BUILD} BH BiocManager MASS Matrix R6 RColorBrewer RCurl Rcpp XML ade4 askpass base64enc \
+		bbmle bdsmatrix bitops brio cachem callr cli clipr colorspace cpp11 crayon credentials curl data.table \
+		desc digest downlit ellipsis evaluate fansi farver fastmap formatR fs futile.logger futile.options gert \
+		ggplot2 ggrepel gh gitcreds glue gtable highr hms htmltools httr ini isoband jsonlite knitr labeling \
+		lambda.r lattice lazyeval lifecycle magrittr markdown matrixStats memoise mgcv mime mockr munsell \
+		mvtnorm nlme numDeriv openssl pbapply pillar pixmap pkgconfig pkgdown plyr poilog prettyunits processx \
+		progress ps purrr ragg rappdirs rematch2 renv reshape2 rlang rmarkdown rprojroot rstudioapi scales \
+		segmented seqinr snow sp stringi stringr sys systemfonts textshaping tibble tinytex usethis utf8 vctrs \
+		viridisLite whisker withr xfun xml2 yaml zip remotes \
+	&& /usr/local/lib/R/site-library/littler/examples/installBioc.r BSgenome BSgenome.Hsapiens.UCSC.hg19 Biobase \
+		BiocGenerics BiocParallel BiocVersion Biostrings DelayedArray GenomeInfoDb GenomeInfoDbData \
+		GenomicAlignments GenomicRanges IRanges MatrixGenerics Rhtslib Rsamtools S4Vectors SummarizedExperiment \
+		XVector rtracklayer zlibbioc deconstructSigs \
+	&& installGithub.r -u FALSE im3sanger/dndscv "Townsend-Lab-Yale/cancereffectsizeR@*release" \
+	&& installGithub.r -u FALSE "Townsend-Lab-Yale/ces.refset.hg19@*release"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # <span style="color:#224570;font-size:115%"><em>cancereffectsizeR</em></span><br><span style="font-size:65%; color:#224570">Townsend Lab, Yale School of Public Health</span>
 
+<!-- MarkdownTOC autolink="true" -->
+
+- [Welcome](#welcome)
+- [Getting started](#getting-started)
+	- [Quick start, using Docker image](#quick-start-using-docker-image)
+		- [Running container with Singularity](#running-container-with-singularity)
+		- [Run package tests](#run-package-tests)
+	- [Manual installation](#manual-installation)
+		- [R 4.0 and later](#r-40-and-later)
+		- [R 3.5 and 3.6](#r-35-and-36)
+- [Publications and version note](#publications-and-version-note)
+
+<!-- /MarkdownTOC -->
+
 ## Welcome
 cancereffectsizeR aims to provide an intuitive and comprehensive set of tools to quantify the effects of somatic variants on cancer progression. Throughout the package, methods are designed to support as little or as much customization as you like:
 - Annotate variants with built-in reference data, or create a [custom reference data set](articles/custom_refset_instructions.html) for any genome build.
@@ -12,7 +26,64 @@ For a more detailed overview, see [Get Started](articles/cancereffectsizeR.html)
 
 Currently, cancereffectsizeR directly supports analysis of both noncoding and amino-acid-changing SNVs. Current methods provide some insight into interactions with other types of selection; for example, samples could be grouped by copy number status (or any other feature of interest) and assessed for differential SNV selection. We plan to extend cancereffectsizeR's functionality as we continue development, and we welcome your feedback, ideas, and bug reports.
 
-## Installation
+
+## Getting started
+
+The sections below describe a [no-installation approach](#quick-start-using-docker-image) using Docker (or Singularity), and instructions on [how to install the package into your local R environment](#manual-installation).
+
+### Quick start, using Docker image
+
+The quickest way to try out cancereffectsizeR is to use the Docker container image on [Docker Hub](https://hub.docker.com/r/townsendlab/cancereffectsizer), which has the R package, dependencies, and R Studio bundled in. With Docker [installed and running](https://www.docker.com/get-started) on your machine, run the following command in the terminal to download the image and launch RStudio:
+```shell script
+docker run --rm -e PASSWORD=rstudiopassword -p 8787:8787 townsendlab/cancereffectsizer
+```
+RStudio will be accessible in your browser at http://localhost:8787, with username `rstudio` and custom password `rstudiopassword`.
+
+To open RStudio with your current directory available as the default working directory (`/home/rstudio`), run:
+```shell script
+docker run --rm -e PASSWORD=rstudiopassword -v $PWD:/home/rstudio \
+  -p 8787:8787 townsendlab/cancereffectsizer
+```
+
+Alternatively, to open the R interpreter, with your current directory as working directory, bound to `/work` in the container, run:
+```shell script
+docker run --rm -ti -v $PWD:/work -w /work townsendlab/cancereffectsizer R
+```
+
+#### Running container with Singularity
+
+If you work in an HPC environment that uses [Singularity](https://sylabs.io/guides/latest/user-guide/) to run containers, you can launch RStudio with the following commands:
+```shell script
+export SINGULARITYENV_USER=$USER
+export SINGULARITYENV_PASSWORD=rstudiopassword
+
+mkdir -p /tmp/$USER run var-lib-rstudio-server
+printf 'provider=sqlite\ndirectory=/var/lib/rstudio-server\n' > database.conf
+
+singularity exec -C --home $(pwd):/home/rstudio \
+  -B /tmp/${USER}:/tmp,$(pwd):/home/rstudio,run:/run \
+  -B var-lib-rstudio-server:/var/lib/rstudio-server \
+  -B database.conf:/etc/rstudio/database.conf \
+  docker://townsendlab/cancereffectsizer rserver \
+  --auth-none=0 --auth-pam-helper-path=pam-helper \
+  --auth-timeout-minutes=0 --auth-stay-signed-in-days=30 \
+  --www-address=0.0.0.0  --www-port 8787
+```
+As with running under Docker, RStudio will be accessible in your browser at http://localhost:8787, with username `rstudio` and custom password `rstudiopassword`. When running a remote machine, you will need to set up a tunnel for browser access, e.g.:
+```shell script
+ssh -N -L 8787:compute-node:8787 login-node
+```
+
+#### Run package tests
+
+The container image includes the repository code at `/cancereffectsizeR`, which has a `tests` subdirectory. You can run the tests within the R interpreter or RStudio with:
+```R
+testthat::test_local('/cancereffectsizeR')
+```
+
+
+### Manual installation
+
 cancereffectsizeR requires R 3.5 or later and can be installed from its GitHub repository via the remotes package. Since we're not able to test all installation environments, please help by letting us know if you have any installation problems.
 
 #### R 4.0 and later

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ cancereffectsizeR requires R 3.5 or later and can be installed from its GitHub r
 On R 4.0 or later, run this:
 ```R
 install.packages("remotes")
+options(timeout = 300)  # allow extra time to download BSgenome.Hsapiens.UCSC.hg19
 remotes::install_github("Townsend-Lab-Yale/cancereffectsizeR@*release")
 ```
 


### PR DESCRIPTION
Uses Rocker Rstudio 4.0.5 base. Build arguments allow modification of CRAN snapshot and Bioconductor release, and CPU count for dependency installation step.

Example run commands below assume auto-build to Docker Hub as `townsendlab/cancereffectsizer`:

Run rstudio, accessible via browser at `localhost:8787`:
```bash
docker run --rm -e PASSWORD=<YOUR_PASS> -p 8787:8787 townsendlab/cancereffectsizer
```

Open R interpreter, bind current directory to `/work`, and use as working directory:
```bash
docker run --rm -ti -v ${PWD}:/work -w /work townsendlab/cancereffectsizer R
```